### PR TITLE
Rjdev

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as infile:
 
 setup(
 	name = "smmips",
-	version = '1.0.2',
+	version = '1.0.3',
 	author = "Richard Jovelin",
 	author_email = "richard.jovelin@oicr.on.ca",
 	description = ("A package to analyse smMIP libraries"),

--- a/smmips/smmips.py
+++ b/smmips/smmips.py
@@ -45,9 +45,9 @@ def align_reads(outdir, fastq1, fastq2, reference, bwa, prefix, remove):
     align_fastqs(fastq1, fastq2, reference, outdir, bwa, prefix, remove)
 
 
-def assign_smmips(outdir, sortedbam, prefix, chromosome, remove, panel, upstream_nucleotides,
+def assign_smmips(outdir, sortedbam, prefix, remove, panel, upstream_nucleotides,
                   umi_length, max_subs, match, mismatch, gap_opening, gap_extension,
-                  alignment_overlap_threshold, matches_threshold):
+                  alignment_overlap_threshold, matches_threshold, chromosome, start, end):
     '''
     (str, str, str, str, bool, str, int, int, int, float | int, float | int, float | int, float | int, float | int , float | int) -> None
     

--- a/smmips/smmips.py
+++ b/smmips/smmips.py
@@ -119,6 +119,9 @@ def assign_smmips(outdir, sortedbam, prefix, remove, panel, upstream_nucleotides
     infile.close()
     
     # assign reads to smmips
+    # start and end position parameters valid only if chromosome is defined
+    if chromosome is None:
+        start, end = None, None
     metrics, smmip_counts = assign_reads_to_smmips(sortedbam, assigned_file, empty_file, read_panel(panel), upstream_nucleotides, umi_length, max_subs, match, mismatch, gap_opening, gap_extension, alignment_overlap_threshold, matches_threshold, chromosome, start, end)
     
     # close bams    

--- a/smmips/smmips.py
+++ b/smmips/smmips.py
@@ -73,12 +73,10 @@ def assign_smmips(outdir, sortedbam, prefix, remove, panel, upstream_nucleotides
     - start (int | None): Start position of region on chromosome if defined
     - end (int | None): End position of region on chromosome if defined
     
-    Write assigned reads, assigned but empty smmips and unassigned
-    reads to 3 separate output bams, coordinate-sorted and indexed.
+    Write assigned reads and empty smmips to 2 separate coordinate-sorted and indexed bams.
     Assigned reads are tagged with the smMip name and the extracted UMI sequence.
-    Also write 2 json files in outdir/stats for QC
-    with counts of total, assigned and unassigned read along with empty smmips,
-    and read count for each smmip in the panel
+    Also write 2 json files in outdir/stats for QC with counts of total, assigned
+    and unassigned read along with empty smmips, and read count for each smmip in the panel
     '''
     
     # record time spent smmip assignment
@@ -106,10 +104,12 @@ def assign_smmips(outdir, sortedbam, prefix, remove, panel, upstream_nucleotides
         # open bam for writing assigned but empty reads
         empty_filename = remove_bam_extension(sortedbam) + '.empty_reads.bam'
     else:
+        start_pos = 'start' if start is None else str(start)
+        end_pos = 'end' if end is None else str(end)
         # create a new file, use header from bamfile
-        assigned_filename = remove_bam_extension(sortedbam) + '.{0}.temp.assigned_reads.bam'.format(chromosome)
+        assigned_filename = remove_bam_extension(sortedbam) + '.{0}.temp.assigned_reads.bam'.format('.'.join([chromosome, start_pos, end_pos]))
         # open bam for writing assigned but empty reads
-        empty_filename = remove_bam_extension(sortedbam) + '.{0}.temp.empty_reads.bam'.format(chromosome)
+        empty_filename = remove_bam_extension(sortedbam) + '.{0}.temp.empty_reads.bam'.format('.'.join([chromosome, start_pos, end_pos]))
     
     
     assigned_file = pysam.AlignmentFile(assigned_filename, 'wb', template=infile)
@@ -148,8 +148,10 @@ def assign_smmips(outdir, sortedbam, prefix, remove, panel, upstream_nucleotides
         statsfile1 = os.path.join(statsdir, '{0}_extraction_metrics.json'.format(prefix))
         statsfile2 = os.path.join(statsdir, '{0}_smmip_counts.json'.format(prefix))
     else:
-        statsfile1 = os.path.join(statsdir, '{0}_temp.{1}.extraction_metrics.json'.format(prefix, chromosome))
-        statsfile2 = os.path.join(statsdir, '{0}_temp.{1}.smmip_counts.json'.format(prefix, chromosome))
+        start_pos = 'start' if start is None else str(start)
+        end_pos = 'end' if end is None else str(end)
+        statsfile1 = os.path.join(statsdir, '{0}_temp.{1}.extraction_metrics.json'.format(prefix, '.'.join([chromosome, start_pos, end_pos])))
+        statsfile2 = os.path.join(statsdir, '{0}_temp.{1}.smmip_counts.json'.format(prefix, '.'.join([chromosome, start_pos, end_pos])))
     with open(statsfile1, 'w') as newfile:
         json.dump(metrics, newfile, indent=4)
     with open(statsfile2, 'w') as newfile:

--- a/smmips/smmips_libs.py
+++ b/smmips/smmips_libs.py
@@ -642,9 +642,9 @@ def sort_index_bam(filename, suffix):
     pysam.index(sorted_file)
 
 
-def assign_reads_to_smmips(bamfile, assigned_file, unassigned_file, empty_file, chromosome, panel, upstream_nucleotides, umi_length, max_subs, match, mismatch, gap_opening, gap_extension, alignment_overlap_threshold, matches_threshold):
+def assign_reads_to_smmips(bamfile, assigned_file, unassigned_file, empty_file, panel, upstream_nucleotides, umi_length, max_subs, match, mismatch, gap_opening, gap_extension, alignment_overlap_threshold, matches_threshold, chromosome):
     '''
-    (str, pysam.AlignmentFile, pysam.AlignmentFile, pysam.AlignmentFile, str, dict, int, int, int, float, float, float, float, float, float, bool) -> (dict, dict)
+    (str, pysam.AlignmentFile, pysam.AlignmentFile, pysam.AlignmentFile, dict, int, int, int, float, float, float, float, float, float, bool, str | None) -> (dict, dict)
     
     Return a tuple of dictionaries with read counts. The first dictionary counts
     total reads, assigned and unassigned reads as well as empty smmips.
@@ -661,10 +661,10 @@ def assign_reads_to_smmips(bamfile, assigned_file, unassigned_file, empty_file, 
     - assigned_file (pysam.AlignmentFile): Bam file opened to write assigned reads
     - unassigned_file (pysam.AlignmentFile): Bam file opened to write unassigned reads
     - empty_file (pysam.AlignmentFile): Bam file opened to write empty reads
-    - chromosome (str): Specifies the genomic region in the alignment file where reads are mapped 
-                        Valid values:
-                        - all: loop through all chromosomes in the bam
-                        - chrA: specific chromosome. Format must correspond to the chromosome format in the bam file
+    - chromosome (str | None): Specifies the genomic region in the alignment file where reads are mapped 
+                               Valid values:
+                               - None: loop through all chromosomes in the bam
+                               - chrA: specific chromosome. Format must correspond to the chromosome format in the bam file
     - panel (dict): Panel information        
     - upstream_nucleotides (int): Maximum number of nucleotides upstream the UMI sequence
     - umi_length (int): Length of the UMI    
@@ -694,7 +694,7 @@ def assign_reads_to_smmips(bamfile, assigned_file, unassigned_file, empty_file, 
     
     # check that chromosome is in the bam header
     # use all chromosomes 
-    if chromosome != 'all':
+    if chromosome:
         bam_chromosomes = [chromosome] if chromosome in bam_chromosomes else []
     
     # only look at reads expected to map on chromosomes in panel

--- a/smmips/smmips_libs.py
+++ b/smmips/smmips_libs.py
@@ -666,7 +666,7 @@ def get_positions(start, end, chromo_length):
         else:
             end_pos = end
     else:
-        end = chromo_length
+        end_pos = chromo_length
     return start_pos, end_pos
 
 

--- a/smmips/smmips_libs.py
+++ b/smmips/smmips_libs.py
@@ -1316,12 +1316,19 @@ def merge_stats(L):
     '''
     
     # create a dict to count reads over all chromosomes
-    D = {"reads": 0, "assigned": 0, "not_assigned": 0, "assigned_empty": 0, "assigned_not_empty": 0}
+    D = {"reads": 0, "assigned": 0, "assigned_empty": 0, "assigned_not_empty": 0}
     
     for i in L:
         for j in D.keys():
             D[j] += i[j]
     
+    # compute unassigned read count
+    D["not_assigned"] = D['reads'] - D['assigned']
+    
+    # add total number of reads in file
+    D['total'] = L[0]['total']
+    
+    # add ratios
     D['percent_assigned'] = round(D['assigned'] / D['reads'] * 100, 4) if D['reads'] != 0 else 0
     D['percent_not_assigned'] = round(D['not_assigned'] / D['reads'] * 100, 4) if D['reads'] != 0 else 0
     D['percent_empty_smmips'] = round(D['assigned_empty'] / D['assigned'] * 100, 4) if D['assigned'] != 0 else 0

--- a/smmips/smmips_libs.py
+++ b/smmips/smmips_libs.py
@@ -722,9 +722,6 @@ def assign_reads_to_smmips(bamfile, assigned_file, empty_file, panel, upstream_n
     header = get_bam_header(bamfile)
     bam_chromosomes = [i['SN'] for i in header['SQ']]
     
-    # get the length of chromosomes from the bam header
-    chromo_length = get_chromosome_length(header)
-        
     # use specific chromosome if defined 
     # check that chromosome is in the bam header
     if chromosome:


### PR DESCRIPTION
- enables specifying a region defined by chromosome, start and end. all 3 parameters are optional. 
examine reads mapped to all chromosomes if chromosome is not defined. examine reads in region bounded by start and end on chromosome if chromosome is specified. start and end are respectively start and end of the chromosome if not defined
- the workflow will enable parallelization by genomic region and will use smmipRegionFinder.py to identify region coordinates
- does not write unassigned reads to file
- report the total number of reads in the alignment file
- redefined read counts: number of reads mapped to the regions examines
- unassigned read counts is defined as the number of reads in examined region minus the number of assigned reads
- read counts now exclude unmapped reads 
